### PR TITLE
fix minor bug when no view in window 

### DIFF
--- a/adbview.py
+++ b/adbview.py
@@ -242,6 +242,8 @@ def output(pipe):
 
 
 def is_adb_syntax(view):
+    if not view:
+        return False
     sn = view.scope_name(view.sel()[0].a)
     return sn.startswith("source.adb")
 


### PR DESCRIPTION
reproduce by opening Command Palette when no view in window.

Traceback (most recent call last):
  File "./sublime_plugin.py", line 282, in is_visible_
  File "./adbview.py", line 324, in is_visible
  File "./adbview.py", line 321, in is_enabled
  File "./adbview.py", line 245, in is_adb_syntax
AttributeError: 'NoneType' object has no attribute 'scope_name'
