### PR TITLE
Made it possible to select between multiple devices

### DIFF
--- a/ADBView.sublime-settings
+++ b/ADBView.sublime-settings
@@ -1,6 +1,9 @@
 {
-    //ADB command and arguments that should be used.
-    "adb_command": ["adb", "logcat"],
+    //ADB command location.
+    "adb_command": "adb",
+
+    //ADB arguments that should be used.
+    "adb_args": ["logcat"],
 
     //Set to false to disable auto scroll of the ADB view
     "adb_auto_scroll": false,

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,40 @@
+[
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "ADBView",
+                        "children":
+                        [
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/ADBView/ADBView.sublime-settings"},
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/ADBView.sublime-settings"},
+                                "caption": "Settings – User"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/ADBView/README.creole"},
+                                "caption": "README"
+                            },
+                            { "caption": "-" }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Related to issue #5

I've altered the config to allow specifying location of adb and added menu options for easily editing user settings.

Now when ctrl+alt+d is pressed, a quick panel is shown listing `[name] [version] - [device_id]`.

Where these values come from:
- Device ids are received from `adb devices`
- Version comes from `/system/build.prop` on device
- Real device name comes from `/system/build.prop` on device
- Emulator name comes from issuing `avd name` over telnet
