### PR TITLE
py3 fix for reading emu name, fixes #17

### DIFF
--- a/adbview.py
+++ b/adbview.py
@@ -438,9 +438,9 @@ class AdbLaunch(sublime_plugin.WindowCommand):
             if device.startswith("emulator"):
                 port = int(device.rsplit("-")[-1])
                 t = telnetlib.Telnet("localhost", port)
-                t.read_until("OK", 1000)
-                t.write("avd name\n")
-                product = t.read_until("OK", 1000)
+                t.read_until(b"OK", 1000)
+                t.write(b"avd name\n")
+                product = t.read_until(b"OK", 1000).decode("utf-8")
                 t.close()
                 product = product.replace("OK", "").strip()
             else:


### PR DESCRIPTION
should be backwards compat with py2 but not tested in ST2
