### PR TITLE
Options to filter by app Package name and Clear logcat internally

### DIFF
--- a/ADBView.sublime-settings
+++ b/ADBView.sublime-settings
@@ -26,7 +26,4 @@
     
     // full or partial app package name to filter log
     "adb_app_package": "",
-    
-    // clear the logcat before new adb window opens (calls 'logcat -c')
-    "adb_clear_on_launch": false
 }

--- a/adbview.sublime-commands
+++ b/adbview.sublime-commands
@@ -4,6 +4,11 @@
         "command": "adb_launch"
     },
     {
+        "caption":"ADB: Launch Fresh",
+        "command": "adb_launch",
+        "args": {"fresh_logcat": true}
+    },
+    {
         "caption": "ADB: Set Regex filter",
         "command": "adb_set_filter"
     },


### PR DESCRIPTION
Changes:

- 'process_shell' variable will put 'shell' parameter to 'subprocess.Popen' depending on Windows/OrNot OS (as on Windows shell=False provokes flashing of CommanLine windows when each subprocess is run)
- new options: "adb_app_package" (app package name for logcat filter), "adb_clear_on_launch" (clears logcat before new log window opened, 'logcat -c' command)
- methods for searching PID by app package ('update_app_pid'), clearing logcat ('clear_logcat'), adding plain text line to the view ('add_text')
- 'update_app_pid' is run in the '__process_thread' to catch PID changes for the same app package (if app restarts or starts after the logcat opens)
- 'add_text' method is used to inform about 'Loading...' process at the start and if the app PID wasn't found (as with the "adb_app_package" option it needs some time to filter the initial bunch of logs)

New option **"adb_app_package"** allows to filter by app package name (or by app PID which is retrieved from the package).  
Was trying to reproduce the Eclipse Logcat filtering where you can put the app name/package and it loads messages with any tag that belong to your app. Using the log tag in **"adb_args"** works fine but when an exception occurs, for example, you don't see it if its tag is different, and filtering by app name only prints the head of the exception without the stack trace.

Though with this option the log should be large enought or full to be able to filter all messages for the app PID/package. It may need some time when the launch command starts, so I added text messages for **'Loading...'** and **'PID found'**.

Also the **"update_app_pid()"** method is used in the thread to periodically check for possible PID changes. 
Don't know if the place I've put it is the best for performance, but in my case works well.

Thanks.