### PR TITLE
Match the package name against full process name

### DIFF
--- a/adbview.py
+++ b/adbview.py
@@ -287,7 +287,7 @@ class ADBView(object):
         if self.__app_package:
             adb = get_setting("adb_command")
             # cmd_pid = [adb, "shell", "pidof", self.__app_package]
-            cmd_pid = [adb, "shell", "pgrep", self.__app_package]
+            cmd_pid = [adb, "shell", "pgrep", "-f", self.__app_package]
             proc_pid = subprocess.Popen(cmd_pid, shell=process_shell, stdout=subprocess.PIPE)
             app_pid, err = proc_pid.communicate()
             


### PR DESCRIPTION
By default, `pgrep` will match the pattern against the process name given in `/proc/pid/stat` which might be truncated.  
Therefore, it's better to use the `-f` option to force matching against the full name. See docs https://linux.die.net/man/1/pgrep  

You can verify this issue by comparing these two commands:
```bash
⇢adb shell 'pgrep -l "^com\.android\."'
5740 com.android.nfc

⇢adb shell 'pgrep -lf "^com\.android\."'
5424 com.android.systemui
5740 com.android.nfc
5763 com.android.phone
7518 com.android.bluetooth
8663 com.android.chrome:sandboxed
10317 com.android.chrome:sandboxed
10368 com.android.chrome
12601 com.android.vending
13238 com.android.vending:download_service
17189 com.android.settings:QuickSettingsTile
```